### PR TITLE
Fix PostgreSQL syntax error in update_thread method

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -565,7 +565,7 @@ class ChainlitDataLayer(BaseDataLayer):
             INSERT INTO "Thread" ({", ".join(columns)})
             VALUES ({", ".join(placeholders)})
             ON CONFLICT (id) DO UPDATE
-            SET {", ".join(update_sets)};
+            SET {", ".join(update_sets)}
         """
 
         await self.execute_query(query, {str(i + 1): v for i, v in enumerate(values)})


### PR DESCRIPTION
### Description
This PR fixes a PostgreSQL syntax error that occurs when updating threads in the `ChainlitDataLayer`. The issue is caused by a trailing semicolon in the parameterized SQL query.

### Problem
When using `asyncpg` with parameterized queries, trailing semicolons in SQL statements cause a `PostgresSyntaxError`. This prevents thread updates from being persisted to the database.

**Error message:**
```console
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near ";"
```

### Solution
Remove the trailing semicolon from the SQL query in the `update_thread` method.

### Testing
- Tested with PostgreSQL 17 and asyncpg 0.30.0
- Verified that thread updates now work correctly without syntax errors
- File uploads and thread persistence functioning as expected

### Impact
This is a critical fix that affects all users using PostgreSQL as their data persistence layer. Without this fix, thread metadata cannot be properly updated, breaking the conversation history feature.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a PostgreSQL syntax error in the update_thread method by removing a trailing semicolon from the SQL query, allowing thread updates to work correctly with asyncpg.

<!-- End of auto-generated description by cubic. -->

